### PR TITLE
fix(ci): Add GH_TOKEN secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   release:
+    environment: prod
     runs-on: ubuntu-latest
     if: "!contains(toJSON(github.event.commits.*.message), '[skip-ci]') && !contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     steps:
@@ -35,7 +36,7 @@ jobs:
           semantic_version: ${{ env.SEMANTIC_VERSION }}
           working_directory: lua/5.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - if: steps.semantic.outputs.new_release_published == 'true'
         run: |
           echo "Version => ${{ steps.semantic.outputs.new_release_version }}"


### PR DESCRIPTION
As GITHUB_TOKEN is not used to avoid inifinte loops.

More: https://github.com/semantic-release/semantic-release/discussions/1906